### PR TITLE
Use existing secret rework

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (lint)
         run: ct lint --chart-dirs . --charts . --target-branch ${{ github.event.repository.default_branch }}

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.1.5
+version: 0.2.0
 appVersion: 2.0.0
 keywords:
   - web analytics

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -60,3 +60,15 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Define the name of the secret to use
+*/}}
+{{- define "plausible-analytics.secretName" -}}
+{{- if .Values.secret.existingSecret -}}
+{{- .Values.secret.existingSecret -}}
+{{- else -}}
+{{- template "plausible-analytics.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "plausible-analytics.fullname" . }}
+  labels:
+    {{- include "plausible-analytics.labels" . | nindent 4 }}
+data:
+  wait-for-postgres.sh: |
+    #!/bin/sh
+    url="$DATABASE_URL"
+
+    info=$(echo $url | awk '{ gsub(/postgres:\/\//, "", $0); print }')
+    host=$(echo $info | awk -F[@:/] '{print $3}')
+    port=$(echo $info | awk -F[@:/] '{print $4}')
+    user=$(echo $info | awk -F[@:/] '{print $1}')
+    db=$(echo $info | awk -F[@:/] '{print $5}')
+
+    until pg_isready -h "$host" -p "$port" -U "$user" -d "$db"; do
+      echo "Waiting for PostgreSQL to be ready..."
+      sleep 2
+    done
+    echo "PostgreSQL is ready."
+  wait-for-clickhouse.sh: |
+    #!/bin/sh
+    url="$CLICKHOUSE_DATABASE_URL"
+
+    info=$(echo $url | awk '{ gsub(/https?:\/\//, "", $0); print }')
+    host=$(echo $info | awk -F[/:@] '{print $3}')
+    user=$(echo $info | awk -F[/:@] '{print $1}')
+    password=$(echo $info | awk -F[/:@] '{print $2}')
+
+    until clickhouse-client \
+      --host "$host" --port 9000 \
+      --user "$user" --password "$password" \
+      --query "SELECT version()"; do
+      echo "Waiting for ClickHouse to be ready..."
+      sleep 2
+    done
+    echo "ClickHouse is ready."

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,26 +28,37 @@ spec:
       serviceAccountName: {{ include "plausible-analytics.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      volumes:
+        - name: scripts-volume
+          configMap:
+            name: {{ include "plausible-analytics.fullname" . }}
       initContainers:
         - name: wait-for-postgres
           image: postgres:13.3-alpine
-          command: ['sh', '-c', 'until pg_isready -h {{ .Values.postgresql.host }} -p {{ .Values.postgresql.port }} -U {{ .Values.postgresql.auth.username }}; do echo "Waiting for PostgreSQL to be ready..."; sleep 2; done;']
-        {{- if .Values.clickhouse.initContainersClient.enabled }}
-        - name: wait-for-clickhouse
-          image: bitnami/clickhouse:23.3.9
-          command: ['sh', '-c', 'until clickhouse-client --host {{ .Values.clickhouse.host }} --port 9000 --user {{ .Values.clickhouse.auth.username }} --password "$CLICKHOUSE_PASSWORD" --query "SELECT version()"; do echo "Waiting for ClickHouse to be ready..."; sleep 2; done;']
-        {{- end }}
-        {{- if .Values.clickhouse.initContainersHttp.enabled }}
-        - name: wait-for-clickhouse
-          image: curlimages/curl:8.2.1
-          command: ['sh', '-c', 'until curl --fail --silent --output /dev/null {{ .Values.clickhouse.host }}; do echo "Waiting for ClickHouse to be ready..."; sleep 2; done;']  
-        {{- end }}
-          env:  
-            - name: CLICKHOUSE_PASSWORD
+          command: ['sh', '/scripts/wait-for-postgres.sh']
+          env:
+            - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  key: CLICKHOUSE_PASSWORD
-                  name: {{ include "plausible-analytics.fullname" . }}
+                  key: DATABASE_URL
+                  name: {{ include "plausible-analytics.secretName" . }}
+          volumeMounts:
+            - name: scripts-volume
+              mountPath: /scripts
+        - name: wait-for-clickhouse
+          image: bitnami/clickhouse:23.3.9
+          command: ['sh', '/scripts/wait-for-clickhouse.sh']
+          env:
+            - name: CLICKHOUSE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: CLICKHOUSE_DATABASE_URL
+                  name: {{ include "plausible-analytics.secretName" . }}
+          volumeMounts:
+            - name: scripts-volume
+              mountPath: /scripts
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -68,164 +79,11 @@ spec:
             - name: LISTEN_IP
               value: {{ .Values.listenip | toString | quote }}
             {{- end }}
-            {{- if .Values.adminUser.email }}
-            - name: ADMIN_USER_EMAIL
-              valueFrom:
-                secretKeyRef:
-                  key: ADMIN_USER_EMAIL
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.adminUser.name }}
-            - name: ADMIN_USER_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: ADMIN_USER_NAME
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.adminUser.password }}
-            - name: ADMIN_USER_PWD
-              valueFrom:
-                secretKeyRef:
-                  key: ADMIN_USER_PWD
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.postgresql.url }}
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  key: DATABASE_URL
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
                   key: SECRET_KEY_BASE
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- if .Values.clickhouse.url }}
-            - name: CLICKHOUSE_DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  key: CLICKHOUSE_DATABASE_URL
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.clickhouse.auth.username }}
-            - name: CLICKHOUSE_USER
-              valueFrom:
-                secretKeyRef:
-                  key: CLICKHOUSE_USER
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.clickhouse.auth.password }}
-            - name: CLICKHOUSE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: CLICKHOUSE_PASSWORD
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.enabled }}
-            {{- if .Values.smtp.mailer.emailAddress }}
-            - name: MAILER_EMAIL
-              valueFrom:
-                secretKeyRef:
-                  key: MAILER_EMAIL
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.adapter }}
-            - name: MAILER_ADAPTER
-              valueFrom:
-                secretKeyRef:
-                  key: MAILER_ADAPTER
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.host }}
-            - name: SMTP_HOST_ADDR
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_HOST_ADDR
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.port }}
-            - name: SMTP_HOST_PORT
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_HOST_PORT
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.username }}
-            - name: SMTP_USER_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_USER_NAME
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.password }}
-            - name: SMTP_USER_PWD
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_USER_PWD
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.ssl.enabled }}
-            - name: SMTP_HOST_SSL_ENABLED
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_HOST_SSL_ENABLED
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.smtp.retires }}
-            - name: SMTP_RETRIES
-              valueFrom:
-                secretKeyRef:
-                  key: SMTP_RETRIES
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.google.clientID }}
-            - name: GOOGLE_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  key: GOOGLE_CLIENT_ID
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.google.clientSecret }}
-            - name: GOOGLE_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: GOOGLE_CLIENT_SECRET
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.twitter.consumer.key }}
-            - name: TWITTER_CONSUMER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: TWITTER_CONSUMER_KEY
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.twitter.consumer.secret }}
-            - name: TWITTER_CONSUMER_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: TWITTER_CONSUMER_SECRET
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.twitter.access.token }}
-            - name: TWITTER_ACCESS_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  key: TWITTER_ACCESS_TOKEN
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.twitter.access.secret }}
-            - name: TWITTER_ACCESS_TOKEN_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: TWITTER_ACCESS_TOKEN_SECRET
-                  name: {{ include "plausible-analytics.fullname" . }}
-            {{- end }}
-            {{- if .Values.disableAuth }}
-            - name: DISABLE_AUTH
-              value: {{ .Values.disableAuth | toString | quote }}
-            {{- end }}
+                  name: {{ include "plausible-analytics.secretName" . }}
             {{- if .Values.disableRegistration }}
             - name: DISABLE_REGISTRATION
               value: {{ .Values.disableRegistration | toString | quote }}
@@ -234,23 +92,122 @@ spec:
             - name: LOG_FAILED_LOGIN_ATTEMPTS
               value: {{ .Values.logFailedLoginAttempts | toString | quote }}
             {{- end }}
-#            {{- if .Values.geolocation.enabled }}
-#            - name: GEOLITE2_COUNTRY_DB
-#              value: "/geoip/GeoLite2-Country.mmdb"
-#            {{ end }}
-            {{- if .Values.postmark.apiKey }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: DATABASE_URL
+                  name: {{ include "plausible-analytics.secretName" . }}
+            - name: CLICKHOUSE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  key: CLICKHOUSE_DATABASE_URL
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- if .Values.mailer.enabled }}
+            {{- if .Values.mailer.email }}
+            - name: MAILER_EMAIL
+              value: {{ .Values.mailer.email | toString | quote }}
+            {{- end }}
+            {{- if .Values.mailer.adapter }}
+            - name: MAILER_ADAPTER
+              value: {{ .Values.mailer.adatper | toString | quote }}
+            {{- end }}
+            {{- if eq .Values.mailer.adapter "Bamboo.SMTPAdapter" }}
+            {{- if .Values.mailer.smtp.host }}
+            - name: SMTP_HOST_ADDR
+              value: {{ .Values.mailer.smtp.host | toString | quote }}
+            {{- end }}
+            {{- if .Values.mailer.smtp.port }}
+            - name: SMTP_HOST_PORT
+              value: {{ .Values.mailer.smtp.port | toString | quote }}
+            {{- end }}
+            {{- if .Values.mailer.smtp.username }}
+            - name: SMTP_USER_NAME
+              value: {{ .Values.mailer.smtp.username | toString | quote }}
+            {{- end }}
+            - name: SMTP_USER_PWD
+              valueFrom:
+                secretKeyRef:
+                  key: SMTP_USER_PWD
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- if .Values.mailer.smtp.ssl }}
+            - name: SMTP_HOST_SSL_ENABLED
+              value: {{ .Values.mailer.smtp.ssl | toString | quote }}
+            {{- end }}
+            {{- if .Values.mailer.smtp.retries }}
+            - name: SMTP_RETRIES
+              value: {{ .Values.mailer.smtp.retries | toString | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.mailer.adapter "Bamboo.PostmarkAdapter" }}
             - name: POSTMARK_API_KEY
               valueFrom:
                 secretKeyRef:
                   key: POSTMARK_API_KEY
-                  name: {{ include "plausible-analytics.fullname" . }}
+                  name: {{ include "plausible-analytics.secretName" . }}
             {{- end }}
-            {{- if .Values.geoliteCountryDB }}
-            - name: GEOLITE2_COUNTRY_DB
+            {{- if eq .Values.mailer.adapter "Bamboo.MailgunAdapter" }}
+            - name: MAILGUN_API_KEY
               valueFrom:
                 secretKeyRef:
-                  key: GEOLITE2_COUNTRY_DB
-                  name: {{ include "plausible-analytics.fullname" . }}
+                  key: MAILGUN_API_KEY
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- if .Values.mailer.mailgun.domain }}
+            - name: MAILGUN_DOMAIN
+              value: {{ .Values.mailer.mailgun.domain | toString | quote }}
+            {{- end }}
+            {{- if .Values.mailer.mailgun.baseURI }}
+            - name: MAILGUN_BASE_URI
+              value: {{ .Values.mailer.mailgun.baseURI | toString | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq .Values.mailer.adapter "Bamboo.MandrillAdapter" }}
+            - name: MANDRILL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: MANDRILL_API_KEY
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- end }}
+            {{- if eq .Values.mailer.adapter "Bamboo.SendGridAdapter" }}
+            - name: SENDGRID_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: SENDGRID_API_KEY
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.extra_geolocation.enabled }}
+            - name: MAXMIND_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: MAXMIND_LICENSE_KEY
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- if .Values.extra_geolocation.maxmind.edition }}
+            - name: MAXMIND_EDITION
+              value: {{ .Values.extra_geolocation.maxmind.edition | toString | quote }}
+            {{- end }}
+            {{- if .Values.extra_geolocation.geolite2CountryDB }}
+            - name: GEOLITE2_COUNTRY_DB
+              value: {{ .Values.extra_geolocation.geolite2CountryDB | toString | quote }}
+            {{- end }}
+            {{- if .Values.extra_geolocation.geolite2CountryDB }}
+            - name: GEONAMES_SOURCE_FILE
+              value: {{ .Values.extra_geolocation.geonamesSourceFile | toString | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.google.enabled }}
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: GOOGLE_CLIENT_ID
+                  name: {{ include "plausible-analytics.secretName" . }}
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: GOOGLE_CLIENT_SECRET
+                  name: {{ include "plausible-analytics.secretName" . }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            {{ toYaml .Values.extraEnv | indent 10 }}
             {{- end }}
           ports:
             - name: http

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -8,79 +8,55 @@ metadata:
   {{- include "plausible-analytics.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.adminUser.email }}
-  ADMIN_USER_EMAIL: {{ .Values.adminUser.email | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.adminUser.password }}
-  ADMIN_USER_PWD: {{ .Values.adminUser.password | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.adminUser.name }}
-  ADMIN_USER_NAME: {{ .Values.adminUser.name | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.postgresql.url }}
-  DATABASE_URL: {{ .Values.postgresql.url | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.clickhouse.url }}
-  CLICKHOUSE_DATABASE_URL: {{ .Values.clickhouse.url | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.clickhouse.auth.username }}
-  CLICKHOUSE_USER: {{ .Values.clickhouse.auth.username | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.clickhouse.auth.password }}
-  CLICKHOUSE_PASSWORD: {{ .Values.clickhouse.auth.password | toString | b64enc }}
-  {{- end }}
+  {{- if .Values.secretKeyBase }}
+  SECRET_KEY_BASE: {{ .Values.secretKeyBase | toString | b64enc }}
+  {{- else }}
   SECRET_KEY_BASE: {{ randAlphaNum 90 | toString | b64enc }}
-  {{- if .Values.smtp.enabled }}
-  {{- if .Values.smtp.mailer.emailAddress }}
-  MAILER_EMAIL: {{ .Values.smtp.mailer.emailAddress | toString | b64enc }}
   {{- end }}
-  {{- if .Values.smtp.adapter }}
-  MAILER_ADAPTER: {{ .Values.smtp.mailer.adapter | toString | b64enc }}
+  {{- if .Values.databaseURL }}
+  DATABASE_URL: {{ .Values.databaseURL | toString | b64enc }}
   {{- end }}
-  {{- if .Values.smtp.host }}
-  SMTP_HOST_ADDR: {{ .Values.smtp.host | toString | b64enc }}
+  {{- if .Values.clickhouseDatabaseURL }}
+  CLICKHOUSE_DATABASE_URL: {{ .Values.clickhouseDatabaseURL | toString | b64enc }}
   {{- end }}
-  {{- if .Values.smtp.port }}
-  SMTP_HOST_PORT: {{ .Values.smtp.port | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.smtp.username }}
-  SMTP_USER_NAME: {{ .Values.smtp.username | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.smtp.password }}
-  SMTP_USER_PWD: {{ .Values.smtp.password | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.smtp.ssl.enabled }}
-  SMTP_HOST_SSL_ENABLED: {{ .Values.smtp.ssl.enabled | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.smtp.retries }}
-  SMTP_RETRIES: {{ .Values.smtp.retries | toString | b64enc }}
+  {{- if .Values.mailer.enabled }}
+  {{- if eq .Values.mailer.adapter "Bamboo.SMTPAdapter" }}
+  {{- if .Values.mailer.smtp.password }}
+  SMTP_USER_PWD: {{ .Values.mailer.smtp.password | toString | b64enc }}
   {{- end }}
   {{- end }}
+  {{- if eq .Values.mailer.adapter "Bamboo.PostmarkAdapter" }}
+  {{- if .Values.mailer.postmarkApiKey }}
+  POSTMARK_API_KEY: {{ .Values.mailer.postmarkApiKey | toString | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.mailer.adapter "Bamboo.MailgunAdapter" }}
+  {{- if .Values.mailer.mailgun.apiKey }}
+  MAILGUN_API_KEY: {{ .Values.mailgun.apiKey | toString | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.mailer.adapter "Bamboo.MandrillAdapter" }}
+  {{- if .Values.mailer.mandrillApiKey }}
+  MANDRILL_API_KEY: {{ .Values.mailer.mandrillApiKey | toString | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.mailer.adapter "Bamboo.SendGridAdapter" }}
+  {{- if .Values.mailer.sendgridApiKey }}
+  SENDGRID_API_KEY: {{ .Values.mailgun.sendgridApiKey | toString | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.extra_geolocation.enabled }}
+  {{- if .Values.extra_geolocation.maxmind.licenseKey }}
+  MAXMIND_LICENSE_KEY: {{ .Values.extra_geolocation.maxmind.licenseKey | toString | b64enc }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.google.enabled }}
   {{- if .Values.google.clientID }}
   GOOGLE_CLIENT_ID: {{ .Values.google.clientID | toString | b64enc }}
   {{- end }}
   {{- if .Values.google.clientSecret }}
   GOOGLE_CLIENT_SECRET: {{ .Values.google.clientSecret | toString | b64enc }}
   {{- end }}
-  {{- if .Values.twitter.consumer.key }}
-  TWITTER_CONSUMER_KEY: {{ .Values.twitter.consumer.key | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.twitter.consumer.secret }}
-  TWITTER_CONSUMER_SECRET: {{ .Values.twitter.consumer.secret | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.twitter.access.token }}
-  TWITTER_ACCESS_TOKEN: {{ .Values.twitter.access.token | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.twitter.access.secret }}
-  TWITTER_ACCESS_TOKEN_SECRET: {{ .Values.twitter.access.secret | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.postmark.apiKey }}
-  POSTMARK_API_KEY: {{ .Values.postmark.apiKey | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.geolocation.account_id }}
-  GEOIPUPDATE_ACCOUNT_ID: {{ .Values.geolocation.account_id | toString | b64enc }}
-  {{- end }}
-  {{- if .Values.geolocation.license_key }}
-  GEOIPUPDATE_LICENSE_KEY: {{ .Values.geolocation.license_key | toString | b64enc }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -4,55 +4,76 @@
 # Declare variables to be passed into your templates.
 
 # plausible analytics configuration
-## see https://plausible.io/docs/self-hosting-configuration
+# see https://plausible.io/docs/self-hosting-configuration
 
-disableAuth: false  # Disables authentication completely, no registration, login will be shown.
-disableRegistration: false  # Disables registration of new users.
-baseURL: http://plausible-analytics.local  # The hosting url of the server, used for URL generation. In production systems, this should be your ingress host.
+## Server
+
+baseURL: http://plausible-analytics.local # The hosting url of the server
 listenIP: 0.0.0.0
+secretKeyBase: "" # is automaticly generated if left empty
+disableRegistration: false  # Restricts registration of new users.
+logFailedLoginAttempts: false # Controls whether to log warnings about failed login attempts.
 
-adminUser:
-  email: admin@example.com  # Admin user's email
-  name: Administrator  # Display name admin user
-  password: secr3t  # Admin user password
+## Databases
+## Plausible require a Postgres and Clickhouse database
 
-# SECRET_KEY_BASE is Helm randAlphaNum 90
+### The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+databaseURL: "postgres://postgres:postgres@plausible-analytics-postgresql:5432/plausible_db"
 
-smtp:  # Plausible uses and SMTP server to send transactional emails e.g. account activation, password reset, weekly reports, etc.
-  enabled: false  # Enable/Disable SMTP functionality
-  mailer:
-    emailAddress:  # the email address of the email sender
-    adapter:
-  host:  # The host address of your smtp server.
-  port:  # The port of your smtp server.
-  username:  # The username/email in case SMTP auth is enabled.
-  password:  # The password in case SMTP auth is enabled.
-  ssl:
-    enabled: false  # If SSL is enabled for SMTP connection
-  retries: 2  # Number of retries to make until mailer gives up.
+### The URL Connection String to clickhouse DB see -> https://clickhouse.tech/docs/en/interfaces/http/
+clickhouseDatabaseURL: "http://clickhouse:password@plausible-analytics-clickhouse:8123/plausible_events_db"
+clickhouseFlushIntervalMS: ""
+clickhouseMaxBufferSize: ""
 
-postmark:  # Alternatively, you can use Postmark to send transactional emails. In this case, use the following parameters:
-  apiKey:
+### Check that postgres and clickhouse are accesible before starting plausible
+initContainers: true
 
-geolocation:  # MaxMind geolocation database#
-  enabled: false  # Enable/Disable the automated fetch of
-  account_id:  # Account/User ID from maxmind.com
-  license_key:  # My License Key from maxmind.com
+### Specifies if the helm chart should create a secret file or use an existingSecret
+secret:
+  create: true
+  existingSecret: ""
 
-# Google Search Integration
-# See: https://docs.plausible.io/self-hosting-configuration#google-search-integration
+## Mailer / SMTP Setup
+## Plausible send transactional emails e.g. account activation, password reset, weekly reports, etc.
+
+mailer:
+  enabled: false  # Enable/Disable functionality
+  email: "" # the email address of the email sender
+  adapter: "" # "Bamboo.SMTPAdapter", "Bamboo.MailgunAdapter", "Bamboo.MandrillAdapter", "Bamboo.SendGridAdapter"
+  smtp:
+    host: "" # The host address of your smtp server.
+    port: "" # The port of your smtp server.
+    username: "" # The username/email in case SMTP auth is enabled.
+    password: "" # The password in case SMTP auth is enabled.
+    ssl: "" # If SSL is enabled for SMTP connection
+    retries: ""  # Number of retries to make until mailer gives up.
+  mailgun:
+    apiKey: ""
+    domain: ""
+    baseURI: ""
+  postmarkApiKey:  ""
+  mandrillApiKey: ""
+  sendgridApiKey: ""
+
+## IP Geolocation
+## Plausible use a free ip <-> country database to enrich analytics optionally
+## you can provide a different database
+
+extra_geolocation:
+  enabled: false  # Enable/Disable
+  maxmind:
+    licenseKey: ""
+    edition: ""
+  geolite2CountryDB: ""
+  geonamesSourceFile: ""
+
+##  Google API Integration Integration
+## See: https://docs.plausible.io/self-hosting-configuration#google-search-integration
+
 google:
+  enabled: false  # Enable/Disable
   clientID:  # The Client ID from the Google API Console for your Plausible Analytics project
   clientSecret:  # The Client Secret from the Google API Console for your Plausible Analytics project
-# Twitter Integration
-# https://docs.plausible.io/self-hosting-configuration#twitter-integration
-twitter:
-  consumer:
-    key:  # The API key from the Twitter Developer Portal
-    secret:  # The API key secret from the Twitter Developer Portal
-  access:
-    token:  # The access token you generated in the steps above
-    secret:  # The access token secret you generated in the steps above
 
 labels: {}  # Extra Labels to apply on your k8s deployment
 
@@ -62,54 +83,45 @@ labels: {}  # Extra Labels to apply on your k8s deployment
 
 postgresql:
   ## If true, install the Postgresql chart
-  ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+  ## ref: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
   enabled: true
-  # The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
-  # url postgres://postgres:postgres@plausible-analytics-postgresql:5432/plausible_db
-  url: postgres://postgres:postgres@plausible-analytics-postgresql:5432/plausible_db
   auth:
     username: postgres
-    # check auth.existingSecret from https://github.com/bitnami/charts/tree/main/bitnami/postgresql
     password: postgres
     database: plausible_db
   port: 5432
-  host: plausible-analytics-postgresql
   replication:
     enabled: false
   metrics:
     enabled: false
-  persistence:
-    enabled: false
+  primary:
+    persistence:
+      enabled: false
 
 # ------------------------------------------------------------------------------
 # Clickhouse:
 # ------------------------------------------------------------------------------
 
-clickhouse:  # Clickhouse Database
+clickhouse:
+  ## If true, install the Clickhouse chart
+  ## ref: https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
   enabled: true
-  # The URL Connection String to clickhouse DB see -> https://clickhouse.tech/docs/en/interfaces/http/
-  url: http://clickhouse:password@plausible-analytics-clickhouse:8123/plausible_events_db
   auth:
     username: clickhouse
-    # password: password or check auth.existingSecret from https://github.com/bitnami/charts/tree/main/bitnami/clickhouse
     password: password
     database: plausible_events_db
-  host: plausible-analytics-clickhouse
-  # should be http://clickhouse.example.com if you use the initContainersHttp method
-  initContainersHttp:
-    enabled: false
-  initContainersClient:
-    enabled: true
   initdbScripts:
     db-init.sql: |
       CREATE DATABASE IF NOT EXISTS plausible_events_db
   # https://github.com/plausible/analytics/discussions/1603 clickhouse cluster is not supported yet.
   shards: 1
-  replicaCounts: 1
+  replicaCount: 1
   zookeeper:
     enabled: false
+  persistence:
+    enabled: false
 
-# kubernetes ressources
+## Kubernetes ressources
 
 replicaCount: 1
 
@@ -122,10 +134,6 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-
-secret:
-  # Specifies if the helm chart should create a secret file
-  create: true
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/values.yaml
+++ b/values.yaml
@@ -8,11 +8,11 @@
 
 ## Server
 
-baseURL: http://plausible-analytics.local # The hosting url of the server
+baseURL: http://plausible-analytics.local  # The hosting url of the server
 listenIP: 0.0.0.0
-secretKeyBase: "" # is automaticly generated if left empty
+secretKeyBase: ""  # is automaticly generated if left empty
 disableRegistration: false  # Restricts registration of new users.
-logFailedLoginAttempts: false # Controls whether to log warnings about failed login attempts.
+logFailedLoginAttempts: false  # Controls whether to log warnings about failed login attempts.
 
 ## Databases
 ## Plausible require a Postgres and Clickhouse database
@@ -38,20 +38,20 @@ secret:
 
 mailer:
   enabled: false  # Enable/Disable functionality
-  email: "" # the email address of the email sender
-  adapter: "" # "Bamboo.SMTPAdapter", "Bamboo.MailgunAdapter", "Bamboo.MandrillAdapter", "Bamboo.SendGridAdapter"
+  email: ""  # the email address of the email sender
+  adapter: ""  # "Bamboo.SMTPAdapter", "Bamboo.MailgunAdapter", "Bamboo.MandrillAdapter", "Bamboo.SendGridAdapter"
   smtp:
-    host: "" # The host address of your smtp server.
-    port: "" # The port of your smtp server.
-    username: "" # The username/email in case SMTP auth is enabled.
-    password: "" # The password in case SMTP auth is enabled.
-    ssl: "" # If SSL is enabled for SMTP connection
+    host: ""  # The host address of your smtp server.
+    port: ""  # The port of your smtp server.
+    username: ""  # The username/email in case SMTP auth is enabled.
+    password: ""  # The password in case SMTP auth is enabled.
+    ssl: ""  # If SSL is enabled for SMTP connection
     retries: ""  # Number of retries to make until mailer gives up.
   mailgun:
     apiKey: ""
     domain: ""
     baseURI: ""
-  postmarkApiKey:  ""
+  postmarkApiKey: ""
   mandrillApiKey: ""
   sendgridApiKey: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Use existing secret.

Changes:

I added the ability to bring an existing secrets that we discussed in #3.

I separated the values related to postgres and clickhouse optional deps to be first level `databaseURL`, `clickhouseDatabaseURL`
We can discuss this but I feel like it's confusing to access values from deps that are not supported in their chart and if you want to bring your own postgres or clickhouse it make more sense.

I got ride of the secrets postgres and clickhouse password ... that are only used in the init containers and replaced that by parsing the DB URL in scripts instead. I also moved the init container check on first level for the same reasons as before.
I also got ride of the clickhouse curl check not sure why two scripts are needed ?

I updated the plausible ENV some where removed some where added. (twitter, adminUser, mailer ...)

The chart version need to be bumped but I will do that after the review.

There is an issue with the CI does not seem related with my changes `ERROR: Unable to validate cosign version: 'v2.0.0'`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
