### PR TITLE
[FIX]: Set correct indentation for included env from .Values.extraEnv

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 2.0.0
 keywords:
   - web analytics

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -222,7 +222,7 @@ spec:
                   name: {{ include "plausible-analytics.secretName" . }}
             {{- end }}
             {{- if .Values.extraEnv }}
-            {{ toYaml .Values.extraEnv | indent 10 }}
+{{ toYaml .Values.extraEnv | indent 12 }}
             {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
Hi,

I found an issue with the extraEnv option introduced in #4 

Adding the following option to values.yaml:
```
extraEnv:
  - name: NAME
    value: VALUE
  - name: OTHER
    value: VALUE2
```

Leads to the following deployment.yaml in the template (which fails to deploy):

```
<...>
            - name: CLICKHOUSE_DATABASE_URL
              valueFrom:
                secretKeyRef:
                  key: CLICKHOUSE_DATABASE_URL
                  name: plausible-plausible-analytics
                        - name: NAME
            value: VALUE
          - name: OTHER
            value: VALUE2
<...>
```

There are two problems with https://github.com/IMIO/helm-plausible-analytics/blob/f480d867bbfa6d028830cd05a6d3e30cb4ffa98e/templates/deployment.yaml#L225 

1. The first line is too much indented. This is because the spaces before `{{ toYaml .Values.extraEnv | indent 10 }}` are included in the output template
2. The required indentation should be 12, not 10

In the hope I can help with this PR.

#### Checklist
- [X] Chart Version bumped
