### PR TITLE
Fix SendGrid API key secret

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -42,7 +42,7 @@ data:
   {{- end }}
   {{- if eq .Values.mailer.adapter "Bamboo.SendGridAdapter" }}
   {{- if .Values.mailer.sendgridApiKey }}
-  SENDGRID_API_KEY: {{ .Values.mailgun.sendgridApiKey | toString | b64enc }}
+  SENDGRID_API_KEY: {{ .Values.mailer.sendgridApiKey | toString | b64enc }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
The SendGrid API key feature is buggy. When configured, the deployment cannot be created because `.Values.mailer.sendgridApiKey` is checked but the faulty non-existant name `.Values.mailgun.sendgridApiKey` is included.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
