### PR TITLE
Remove deprecated db init-admin command

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: 2.0.0
 keywords:
   - web analytics

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - /bin/sh
             - -x
             - -c
-            - /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh db init-admin && /entrypoint.sh run
+            - /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run
           env:
             {{- if .Values.baseURL }}
             - name: BASE_URL


### PR DESCRIPTION
#### What this PR does / why we need it:

As per this commit 2 years ago, the `db init-admin` has been deprecated and is now issuing an error on Plausible CE v2.1.0-rc.1:

https://github.com/plausible/analytics/blob/e522a2d7c182f5a0c7b2d95bf3ea248567a529e0/rel/overlays/init-admin.sh#L4-L5

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped