### PR TITLE
update default mailer adapter

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 2.1.1
 keywords:
   - web analytics

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
             - name: MAILER_ADAPTER
               value: {{ .Values.mailer.adapter | toString | quote }}
             {{- end }}
-            {{- if eq .Values.mailer.adapter "Bamboo.SMTPAdapter" }}
+            {{- if eq .Values.mailer.adapter "Bamboo.Mua" }}
             {{- if .Values.mailer.smtp.host }}
             - name: SMTP_HOST_ADDR
               value: {{ .Values.mailer.smtp.host | toString | quote }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -21,7 +21,7 @@ data:
   CLICKHOUSE_DATABASE_URL: {{ .Values.clickhouseDatabaseURL | toString | b64enc }}
   {{- end }}
   {{- if .Values.mailer.enabled }}
-  {{- if eq .Values.mailer.adapter "Bamboo.SMTPAdapter" }}
+  {{- if eq .Values.mailer.adapter "Bamboo.Mua" }}
   {{- if .Values.mailer.smtp.password }}
   SMTP_USER_PWD: {{ .Values.mailer.smtp.password | toString | b64enc }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -54,7 +54,7 @@ secret:
 mailer:
   enabled: false  # Enable/Disable functionality
   email: ""  # the email address of the email sender
-  adapter: ""  # "Bamboo.SMTPAdapter", "Bamboo.MailgunAdapter", "Bamboo.MandrillAdapter", "Bamboo.SendGridAdapter"
+  adapter: ""  # "Bamboo.Mua", "Bamboo.MailgunAdapter", "Bamboo.MandrillAdapter", "Bamboo.SendGridAdapter"
   smtp:
     host: ""  # The host address of your smtp server.
     port: ""  # The port of your smtp server.


### PR DESCRIPTION
#### Which issue this PR fixes

The new mailer default is Mua: https://github.com/plausible/community-edition/wiki/Configuration#mailer_adapter
