### PR TITLE
Support `DATABASE_CACERTFILE`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 2.1.1
 keywords:
   - web analytics

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,11 +28,21 @@ spec:
       serviceAccountName: {{ include "plausible-analytics.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.plausibleInitContainers.enabled }}
       volumes:
+        {{- if .Values.plausibleInitContainers.enabled }}
         - name: scripts-volume
           configMap:
             name: {{ include "plausible-analytics.fullname" . }}
+        {{- end }}
+        {{- if .Values.databaseCA }}
+        - name: database-ca
+          secret:
+            secretName: {{ include "plausible-analytics.secretName" . }}
+            items:
+              - key: DATABASE_CA
+                path: database-ca.pem
+        {{- end }}
+      {{- if .Values.plausibleInitContainers.enabled }}
       initContainers:
         - name: wait-for-postgres
           image: "{{ .Values.plausibleInitContainers.postgresql.image.repository }}:{{ .Values.plausibleInitContainers.postgresql.image.tag | default "latest" }}"
@@ -71,6 +81,11 @@ spec:
           volumeMounts:
             - name: scripts-volume
               mountPath: /scripts
+            {{- if .Values.databaseCA }}
+            - name: database-ca
+              mountPath: /etc/ssl/certs/plausible/
+              readOnly: true
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -83,6 +98,12 @@ spec:
             - -x
             - -c
             - /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run
+          volumeMounts:
+            {{- if .Values.databaseCA }}
+            - name: database-ca
+              mountPath: /etc/ssl/certs/plausible/
+              readOnly: true
+            {{- end }}
           env:
             {{- if .Values.baseURL }}
             - name: BASE_URL
@@ -115,6 +136,10 @@ spec:
                 secretKeyRef:
                   key: DATABASE_URL
                   name: {{ include "plausible-analytics.secretName" . }}
+            {{- if .Values.databaseCA }}
+            - name: DATABASE_CACERTFILE
+              value: /etc/ssl/certs/plausible/database-ca.pem
+            {{- end }}
             - name: CLICKHOUSE_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -60,4 +60,7 @@ data:
   GOOGLE_CLIENT_SECRET: {{ .Values.google.clientSecret | toString | b64enc }}
   {{- end }}
   {{- end }}
+  {{- if .Values.databaseCA }}
+  DATABASE_CA: {{ .Values.databaseCA | toString | b64enc }}
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,8 @@ logFailedLoginAttempts: false  # Controls whether to log warnings about failed l
 
 ### The URL to the Postgres Database Connection String see -> https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 databaseURL: "postgres://postgres:postgres@plausible-analytics-postgresql:5432/plausible_db"
+### CA certificate for the database connection in PEM format. If not provided, the database connection will not use SSL.
+databaseCA: null
 
 ### The URL Connection String to clickhouse DB see -> https://clickhouse.tech/docs/en/interfaces/http/
 clickhouseDatabaseURL: "http://clickhouse:password@plausible-analytics-clickhouse:8123/plausible_events_db"

--- a/values.yaml
+++ b/values.yaml
@@ -143,10 +143,10 @@ clickhouse:
 replicaCount: 1
 
 image:
-  repository: plausible/community-edition
+  repository: ghcr.io/plausible/community-edition
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v2.1.1"
+  tag: "v2.1.4"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds support for the new `DATABASE_CACERTFILE` environment variable (Plausible 2.1.2 and later) by allowing a user to add a trusted root certificate for their database in the values file. This certificate will be stored in a secret and mounted as a volume if set. This is needed because root certificate checks are now enforced but the container is built with an empty / unused trust store. Hence, if connecting to Postgres via TLS, this configuration must be provided.

The PR also updates Plausible to 2.1.4.

#### Which issue this PR fixes
Allows the user to connect to a database via TLS on Plausible 2.1.2 and later. Can help #10 and #17 because üroviding `DATABASE_CACERTFILE` forces a connection using TLS/SSL and supersedes the `?ssl=true` connection string parameter. However, it's not a fix because parameters will still not have an effect on that container and prevent its startup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
