### PR TITLE
Extra volumes and mounts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: plausible-analytics
 description: A Helm Chart for Plausible Analytics - Simple, open-source, lightweight (< 1 KB) and privacy-friendly web analytics alternative to Google Analytics.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 3.0.1
 keywords:
   - web analytics

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
               - key: DATABASE_CA
                 path: database-ca.pem
         {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.plausibleInitContainers.enabled }}
       initContainers:
         - name: wait-for-postgres
@@ -103,6 +106,9 @@ spec:
             - name: database-ca
               mountPath: /etc/ssl/certs/plausible/
               readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             {{- if .Values.baseURL }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
           volumeMounts:
             - name: scripts-volume
               mountPath: /scripts
+            {{- if .Values.databaseCA }}
+            - name: database-ca
+              mountPath: /etc/ssl/certs/plausible/
+              readOnly: true
+            {{- end }}
         {{- if not .Values.plausibleInitContainers.curl.enabled }}
         - name: wait-for-clickhouse
           image: "{{ .Values.plausibleInitContainers.clickhouse.image.repository }}:{{ .Values.plausibleInitContainers.clickhouse.image.tag | default "latest" }}"
@@ -84,11 +89,6 @@ spec:
           volumeMounts:
             - name: scripts-volume
               mountPath: /scripts
-            {{- if .Values.databaseCA }}
-            - name: database-ca
-              mountPath: /etc/ssl/certs/plausible/
-              readOnly: true
-            {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -233,3 +233,18 @@ affinity: {}
 
 ## Extra environment variables definition
 extraEnv: []
+
+## Extra volumes definition
+## Refer to ".spec.volumes" specification : https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: []
+# - name: my_volume
+#   secret:
+#     secretName: my_secret
+#     optional: false
+
+## Extra volumes mounts' definition
+## Refer to ".spec.containers.volumeMounts" specification : https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: []
+# - name: mounted_secret
+#   mountPath: "/etc/mounted_secret"
+#   readOnly: true


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the possibility to define additional volumes and their mounts to the `plausible-analytics` container: in my case it is useful to create a secret with all environment variables (used in the `secret.existingSecret` value) with [Secret provider class for Azure Key vaults](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master), which requires an additional volume in the deployment with a specific path.

Additionally, I have moved the optional `database-ca` volume mount from the `wait-for-clickhouse` init container to the `wait-for-postgres` init container, as the certificates are needed for PostgreSQL.

#### Which issue this PR fixes
  - fixes #25 
  - it could help with #12 

#### Special notes for your reviewer:
Unfortunately I have was done with the PR before reading the contribution guidelines, so I did not add a line to every git commit message, to DCO-sign them. In a second moment I have edited my commit messages to DCO-sign them. Please let me know if it is acceptable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
